### PR TITLE
Release 1.1

### DIFF
--- a/ideascube_setup.sh
+++ b/ideascube_setup.sh
@@ -5,7 +5,7 @@ GIT_REPO_URL="https://github.com/bibliosansfrontieres/ideascube-deploy.git"
 ANSIBLE_BIN="/usr/bin/ansible-pull"
 ANSIBLE_ETC="/etc/ansible/facts.d/"
 BRANCH="master"
-GIT_RELEASE_TAG="v1.0"
+GIT_RELEASE_TAG="v1.1"
 
 [ $EUID -eq 0 ] || {
     echo "Error: you have to be root to run this script." >&2

--- a/roles/balena-engine/files/40-balena-engine
+++ b/roles/balena-engine/files/40-balena-engine
@@ -1,6 +1,0 @@
-#!/bin/sh
-[ "$ACTION" = "ifup" -a "$INTERFACE" = "wan" -o "$DEVICE" = "br-lan" ] && {
-
-systemctl start balena-engine
-
-}

--- a/roles/balena-engine/files/balena-engine.service
+++ b/roles/balena-engine/files/balena-engine.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target procd.service
+After=firewall
 Wants=network-online.target
 Requires=balena-engine.socket
 

--- a/roles/balena-engine/tasks/main.yml
+++ b/roles/balena-engine/tasks/main.yml
@@ -36,6 +36,7 @@
   systemd:
     name: balena-engine
     state: started
+    enabled: yes
     daemon_reload: yes
 
 - name: Install a Python library for the Docker Engine API

--- a/roles/balena-engine/tasks/main.yml
+++ b/roles/balena-engine/tasks/main.yml
@@ -42,9 +42,3 @@
 - name: Install a Python library for the Docker Engine API
   pip:
     name: docker
-
-- name: Execute balena-engine startup script when br-lan interface is up AND firewall already launch
-  copy:
-    src: 40-balena-engine
-    dest: /etc/hotplug.d/iface/40-balena-engine
-    mode: 0775

--- a/roles/cleanup/files/20-firewall
+++ b/roles/cleanup/files/20-firewall
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+[ "$ACTION" = ifup -o "$ACTION" = ifupdate ] || exit 0
+[ "$ACTION" = ifupdate -a -z "$IFUPDATE_ADDRESSES" -a -z "$IFUPDATE_DATA" ] && exit 0
+
+/etc/init.d/firewall start
+
+firewall3 -q network "$INTERFACE" >/dev/null || exit 0
+
+sleep 2
+#avoid race condition to firewall
+/etc/init.d/nodogsplash restart

--- a/roles/cleanup/files/25-dnsmasq
+++ b/roles/cleanup/files/25-dnsmasq
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+. $IPKG_INSTROOT/lib/functions.sh
+. $IPKG_INSTROOT/lib/functions/network.sh
+
+[ "$ACTION" = ifup ] || exit 0
+
+/etc/init.d/dnsmasq start

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -23,15 +23,6 @@
     - nginx.service
   ignore_errors: yes
 
-- name: Enable services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-  with_items:
-    - dnsmasq
-    - firewall
-    - nodogsplash
-
 - name: Remove unwanted packages before upgrading
   apt:
     name: "{{ packages }}"
@@ -40,6 +31,14 @@
   vars:
     packages:
     - nginx
+
+- name: Copy tweaked hotplug.d service script
+  copy:
+    src: {{item}}
+    dest: /etc/hotplug.d/iface/{{item}}
+  with_items:
+    - 20-firewall
+    - 25-dnsmasq
 
 - name: Remove unwanted files
   file:
@@ -58,6 +57,4 @@
    # - nginx.default
    - /srv/
    - /etc/hotplug.d/iface/90-ar2f
-   - /etc/hotplug.d/iface/20-firewall
-   - /etc/hotplug.d/iface/25-dnsmasq
    - /etc/hotplug.d/iface/40-balena-engine

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Copy tweaked hotplug.d service script
   copy:
-    src: {{item}}
+    src: "{{item}}"
     dest: /etc/hotplug.d/iface/{{item}}
   with_items:
     - 20-firewall

--- a/roles/cleanup/tasks/main.yml
+++ b/roles/cleanup/tasks/main.yml
@@ -23,12 +23,14 @@
     - nginx.service
   ignore_errors: yes
 
-# - name: Enable services
-#   systemd:
-#     name: "{{ item }}"
-#     enabled: yes
-#   with_items:
-#     - dnsmasq
+- name: Enable services
+  systemd:
+    name: "{{ item }}"
+    enabled: yes
+  with_items:
+    - dnsmasq
+    - firewall
+    - nodogsplash
 
 - name: Remove unwanted packages before upgrading
   apt:
@@ -56,3 +58,6 @@
    # - nginx.default
    - /srv/
    - /etc/hotplug.d/iface/90-ar2f
+   - /etc/hotplug.d/iface/20-firewall
+   - /etc/hotplug.d/iface/25-dnsmasq
+   - /etc/hotplug.d/iface/40-balena-engine


### PR DESCRIPTION
Try to find a better and stable way to start balena-engine without having issue when the firewall start or reload. To do so, firewall reloading has been disabled, nodogsplash started after firewall rules being applied and balena-engine started after firewall is up

This version seems to be stable through reboot and Ethernet cable plug and unplug