### PR TITLE
Removing project_type variable. Harcoding to ideascube.

### DIFF
--- a/roles/containers/tasks/hugo.yml
+++ b/roles/containers/tasks/hugo.yml
@@ -7,10 +7,10 @@
     restart_policy: always
     state: started
     pull: yes
-    labels: "traefik.frontend.rule=Host:{{ containers[hugo_index].name }}.{{project_type}}"
+    labels: "traefik.frontend.rule=Host:{{ containers[hugo_index].name }}.ideascube"
     # volumes: "/media/hdd/hugo/source:/hugo"
     env:
-      HUGO_BASE_URL: "http://{{ containers[hugo_index].name }}.{{project_type}}"
+      HUGO_BASE_URL: "http://{{ containers[hugo_index].name }}.ideascube"
   tags:
     - pull_container
   when: containers[hugo_index] is defined

--- a/roles/containers/tasks/ideascube.yml
+++ b/roles/containers/tasks/ideascube.yml
@@ -10,13 +10,13 @@
     image: "{{ containers[ideascube_index].image_id }}"
     env:
       IDEASCUBE_ID: "idc"
-      DOMAIN: "{{project_type}}"
+      DOMAIN: "ideascube"
       DEBUG: "False"
     published_ports: 9000:9000
     restart_policy: always
     state: started
     pull: yes
-    labels: "traefik.frontend.rule=Host:{{ containers[ideascube_index].name }}.{{project_type}}"
+    labels: "traefik.frontend.rule=Host:{{ containers[ideascube_index].name }}.ideascube"
     entrypoint: "uwsgi --ini /tmp/ideascube.ini --logto /var/log/uwsgi/ideascube.log"
     volumes:
       - /media/hdd/ideascube:/var/ideascube
@@ -36,7 +36,7 @@
     restart_policy: always
     state: started
     pull: yes
-    labels: traefik.frontend.rule=Host:"{{project_type}},sites.{{project_type}}"
+    labels: traefik.frontend.rule=Host:"ideascube,sites.ideascube"
     volumes:
       - /media/hdd/ideascube/static/:/var/ideascube/static/
       - /media/hdd/ideascube/main/media/:/var/ideascube/main/media/

--- a/roles/containers/tasks/kiwix.yml
+++ b/roles/containers/tasks/kiwix.yml
@@ -7,7 +7,7 @@
     restart_policy: always
     state: started
     pull: yes
-    labels: "traefik.frontend.rule=Host:{{ containers[kiwix_index].name }}.{{project_type}}"
+    labels: "traefik.frontend.rule=Host:{{ containers[kiwix_index].name }}.ideascube"
     volumes: "/media/hdd/ideascube/kiwix:/var/ideascube/kiwix"
   tags:
     - pull_container

--- a/roles/containers/tasks/kolibri.yml
+++ b/roles/containers/tasks/kolibri.yml
@@ -7,7 +7,7 @@
     restart_policy: always
     state: started
     pull: yes
-    labels: "traefik.frontend.rule=Host:{{ containers[kolibri_index].name }}.{{project_type}}"
+    labels: "traefik.frontend.rule=Host:{{ containers[kolibri_index].name }}.ideascube"
     volumes: "/media/hdd/kolibri:/root/.kolibri/"
   tags:
     - pull_container

--- a/roles/containers/templates/default.conf.j2
+++ b/roles/containers/templates/default.conf.j2
@@ -6,7 +6,7 @@ upstream ideascube {
 # configuration of the server
 server {
     listen       80;
-    server_name  {{project_type}};
+    server_name  ideascube;
     charset     utf-8;
 
     # max upload size
@@ -39,7 +39,7 @@ server {
 server {
     listen 80;
 
-    server_name sites.{{project_type}};
+    server_name sites.ideascube;
 
     charset utf-8;
 

--- a/roles/update_device_config/tasks/main.yml
+++ b/roles/update_device_config/tasks/main.yml
@@ -34,27 +34,12 @@
 - debug:
     msg: Ideascube "{{ideascube_index}}", Kolibri "{{kolibri_index}}", Kiwix "{{kiwix_index}}", Hugo "{{hugo_index | default(omit)}}"
 
-- name: Guess if project type is ideasbox
-  set_fact:
-    project_type: ideasbox
-  when: project_name | regex_search('(idb)') == "idb"
-
-- name: Guess if project type is KoomBook
-  set_fact:
-    project_type: koombook
-  when: project_name | regex_search('(kb)') == "kb"
-
-- name: Guess if project type is Ideascube
-  set_fact:
-    project_type: ideascube
-  when: project_name | regex_search('(idc)') == "idc"
-
 - name: Set device name variable
   set_fact:
     hostname: "{{ project_name }}"
     full_device_name: "{{ project_name }}-{{ ansible_default_ipv4.macaddress[11:17] | replace(':', '') }}"
 
-- debug: msg="Start playbook {{ ansible_date_time["date"] }} - {{ ansible_date_time["time"] }} - I'm a {{ project_type }} / {{full_device_name}}"
+- debug: msg="Start playbook {{ ansible_date_time["date"] }} - {{ ansible_date_time["time"] }} - I'm a ideascube / {{full_device_name}}"
 
 - name: Ensure custom facts directory exists
   file:
@@ -78,20 +63,20 @@
   register: conf
 
 - name: Resolv domain and sub-domaine to AP ip address
-  command: uci add_list dhcp.@dnsmasq[0].address='/{{project_type}}/192.168.1.1'
+  command: uci add_list dhcp.@dnsmasq[0].address='/ideascube/192.168.1.1'
   when: conf.stdout == ""
 
 - name: Change nodogsplash URL to redirect to
-  command: uci set nodogsplash.@instance[0].redirecturl='http://{{project_type}}'
+  command: uci set nodogsplash.@instance[0].redirecturl='http://ideascube'
 
 - name: Set gateway name
-  command: uci set nodogsplash.@instance[0].gatewayname='{{project_type}}'
+  command: uci set nodogsplash.@instance[0].gatewayname='ideascube'
 
 - name: Enable nodogsplash
   command: uci set nodogsplash.@instance[0].enabled='1'
 
 - name: Set hostname
-  command: uci set system.@system[0].hostname='{{project_type}}'
+  command: uci set system.@system[0].hostname='ideascube'
 
 - name: Set system wide hostname
   shell: echo {{ full_device_name }} > /etc/hostname

--- a/roles/update_device_config/templates/hosts.j2
+++ b/roles/update_device_config/templates/hosts.j2
@@ -2,4 +2,4 @@
 fe00::0     ip6-localnet
 ff00::0     ip6-mcastprefix
 ff02::1     ip6-allnodes
-192.168.1.1 {{ project_type }} kiwix.{{ project_type }} kolibri.{{ project_type }} sites.{{ project_type }} bsfcampus.{{ project_type }}
+192.168.1.1 ideascube kiwix.ideascube kolibri.ideascube sites.ideascube bsfcampus.ideascube

--- a/roles/update_device_config/templates/splash.html.j2
+++ b/roles/update_device_config/templates/splash.html.j2
@@ -1,13 +1,13 @@
 <html>
 <head>
-	<title>{{project_type}}</title>
+	<title>ideascube</title>
 	<meta http-equiv="refresh" content="3;url=$authtarget">
 </head>
 <body bgcolor="#c3dae6" text="black">
 
 <table border="0" cellpadding="2" cellspacing="0" width="100%">
 <tr>
-	<td align="center"><h3>You will now be redirected to <a href=http://{{project_type}}>{{project_type}}</a></h3></td>
+	<td align="center"><h3>You will now be redirected to <a href=http://ideascube>ideascube</a></h3></td>
 </tr>
 <tr>
 	<td align="center" height="120">


### PR DESCRIPTION
This PR offers a possible solution to issue #12 .
The idea behind is to decide that this playbook's role is to deploy only an IDC device. For other devices, such as koombooks, we should continue to use ansiblecube.